### PR TITLE
Fix for exit code 141 pipefail in rom scans

### DIFF
--- a/has_files.sh
+++ b/has_files.sh
@@ -29,7 +29,8 @@ process_zip () {
   unzip -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
   rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
   echo "hashing ${file}"
-  sum=$(sha1sum "${user_folder}/hashes/${rom_path}/tmp/"* | awk '{print $1;exit}')
+  firstfile=( "${user_folder}/hashes/${rom_path}/tmp/"* )
+  sum=$(sha1sum "$firstfile" | awk '{print $1;exit}')
   rm -R "${user_folder}/hashes/${rom_path}/tmp/"
   printf ${sum^^} > "${user_folder}/hashes/${rom_path}/${file}.sha1"
 }
@@ -41,7 +42,8 @@ process_7z () {
   7z x "${user_folder}${rom_path}/${file}" -o"${user_folder}/hashes/${rom_path}/tmp"
   rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
   echo "hashing ${file}"
-  sum=$(sha1sum "${user_folder}/hashes/${rom_path}/tmp/"* | awk '{print $1;exit}')
+  firstfile=( "${user_folder}/hashes/${rom_path}/tmp/"* )
+  sum=$(sha1sum "$firstfile" | awk '{print $1;exit}')
   rm -R "${user_folder}/hashes/${rom_path}/tmp/"
   printf ${sum^^} > "${user_folder}/hashes/${rom_path}/${file}.sha1"
 }


### PR DESCRIPTION
Fixes #43

When a rom archive contains many files, it can take some time for
`sha1sum` to output shas for every file.

The output of `sha1sum` is piped into an `awk` that reads a single line
and then immediately exits. This causes a race condition: if `sha1sum`
is still writing to the pipe but the reader has exited, the kernel sends
it `SIGPIPE` causing it to exit with code 141.

Since the pipefail option is set, this fails the whole script.

With this change, only the first file in the directory is passed into
`sha1sum`. This should maintain behavior while eliminating the bug.

So far these changes have fixed the issue I was having with many of my 
roms. The issue can be tricky to reproduce because high single core 
performance can pretty much eliminate it. I can share the roms that are 
causing the issue, let me know.