### PR TITLE
Update process_7z to not hash folders

### DIFF
--- a/has_files.sh
+++ b/has_files.sh
@@ -39,8 +39,9 @@ process_zip () {
 process_7z () {
   mkdir -p "${user_folder}/hashes/${rom_path}/tmp"
   echo "unzipping ${file}"
-  7z x "${user_folder}${rom_path}/${file}" -o"${user_folder}/hashes/${rom_path}/tmp"
+  7z e "${user_folder}${rom_path}/${file}" -o"${user_folder}/hashes/${rom_path}/tmp"
   rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
+  find . -empty -type d -delete
   echo "hashing ${file}"
   firstfile=( "${user_folder}/hashes/${rom_path}/tmp/"* )
   sum=$(sha1sum "$firstfile" | awk '{print $1;exit}')

--- a/has_files.sh
+++ b/has_files.sh
@@ -41,7 +41,7 @@ process_7z () {
   echo "unzipping ${file}"
   7z e "${user_folder}${rom_path}/${file}" -o"${user_folder}/hashes/${rom_path}/tmp"
   rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
-  find . -empty -type d -delete
+  find "${user_folder}/hashes/${rom_path}/tmp/" -empty -type d -delete
   echo "hashing ${file}"
   firstfile=( "${user_folder}/hashes/${rom_path}/tmp/"* )
   sum=$(sha1sum "$firstfile" | awk '{print $1;exit}')


### PR DESCRIPTION
Update process_7z to ignore empty files. This PR relates to this issue: https://github.com/linuxserver/emulatorjs/issues/52

There are cases where `process_7z` is returning a non 0 exit code for valid 7z archives. An example archive can be found  on PR 52.

My quick fix for this is:
- Do not respect the archive path structure, flatten files in the archive (L42 change `x` flag to `e`).
- scan for empty files (& folders) after extraction, and delete empty files (L44)
- Continue hash as before

This may not work for all archives, some archives may have complicated nested structures I am not aware of.

