### PR TITLE
Add -j Modifier to unzip commands

### DIFF
--- a/has_files.sh
+++ b/has_files.sh
@@ -26,7 +26,7 @@ rm -Rf "${user_folder}/hashes/${rom_path}/tmp/"
 process_zip () {
   mkdir -p "${user_folder}/hashes/${rom_path}/tmp"
   echo "unzipping ${file}"
-  unzip -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
+  unzip -j -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
   rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
   echo "hashing ${file}"
   firstfile=( "${user_folder}/hashes/${rom_path}/tmp/"* )
@@ -62,7 +62,7 @@ process_nes () {
   if [ $file_type == 'zip' ]; then
     mkdir -p "${user_folder}/hashes/${rom_path}/tmp"
     echo "unzipping ${file}"
-    unzip -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
+    unzip -j -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
     rm "${user_folder}/hashes/${rom_path}/tmp/"*.{txt,nfo,xml,readme,README} &> /dev/null || :
     file_to_sha="${user_folder}/hashes/${rom_path}/tmp/"*
   elif [ $file_type == 'x-7z-compressed' ]; then
@@ -147,7 +147,7 @@ process_bin () {
 process_zip_by_name () {
   mkdir -p "${user_folder}/hashes/${rom_path}/tmp"
   echo "unzipping ${file}"
-  unzip -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
+  unzip -j -q "${user_folder}${rom_path}/${file}" -d "${user_folder}/hashes/${rom_path}/tmp"
   echo "hashing ${file}"
   sum=$(sha1sum "${user_folder}/hashes/${rom_path}/tmp/${file%.*}."* | awk '{print $1;exit}')
   rm -R "${user_folder}/hashes/${rom_path}/tmp/"


### PR DESCRIPTION
When extracting zip archives, if the zip archive has nested folder structures, emulatorjs attempts to hash these folders as files. 
Example log:
```
Scan exited with code: 1

sha1sum: '/data/hashes//<...>/tmp/<nested path>': Is a directory
```

This PR adds the `-j` Modifier to unzip commands to prevent directories from being created. (Similar to #52, but for zip archives)
Manpage for `unzip` https://linux.die.net/man/1/unzip

Desc: 
> junk paths. The archive's directory structure is not recreated; all files are deposited in the extraction directory (by default, the current one).

Edit: Let me know if you want an issue for posterity, and I will create and ref it.